### PR TITLE
Diversity page charts udpate

### DIFF
--- a/diversity-page/ethnicity/js/bar.js
+++ b/diversity-page/ethnicity/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "CSIS Staff Breakdown by Race/Ethnicity"
+    text: "Race/Ethnicity*"
   },
   // Credits
   credits: {
@@ -29,7 +29,8 @@ Highcharts.chart('hcContainer', {
     },
     align: 'center',
     verticalAlign: 'bottom',
-    layout: 'horizontal'
+    layout: 'horizontal',
+    reversed: true
   },
   //  Tooltip 
   tooltip: {

--- a/diversity-page/gender/js/bar.js
+++ b/diversity-page/gender/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "CSIS Staff Breakdown by Gender"
+    text: "Gender*"
   },
   // Credits
   credits: {
@@ -29,7 +29,8 @@ Highcharts.chart('hcContainer', {
     },
     align: 'center',
     verticalAlign: 'bottom',
-    layout: 'horizontal'
+    layout: 'horizontal',
+    reversed: true
   },
   //  Tooltip 
   tooltip: {

--- a/diversity-page/generation/js/bar.js
+++ b/diversity-page/generation/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "CSIS Staff Breakdown by Generation"
+    text: "Generation"
   },
   // Credits
   credits: {
@@ -29,7 +29,8 @@ Highcharts.chart('hcContainer', {
     },
     align: 'center',
     verticalAlign: 'bottom',
-    layout: 'horizontal'
+    layout: 'horizontal',
+    reversed: true
   },
   //  Tooltip 
   tooltip: {
@@ -38,6 +39,12 @@ Highcharts.chart('hcContainer', {
   // X Axis
   xAxis: {
     type: 'category',
+    labels: {
+      formatter: function () {
+        let splitStr = this.value.split('(')
+        return splitStr[0] + '<br/>(' + splitStr[1]
+      }
+    }
   },
   // Y Axis
   yAxis: {


### PR DESCRIPTION
Updated the following:
- Remove "CSIS Staff Breakdown by" from all charts
- Add '*' to ethnicity and gender charts
- Line break between generation name and years
- Reverse order of legend to match order of columns