### PR TITLE
Update titles of diversity page charts

### DIFF
--- a/diversity-page/ethnicity/index.html
+++ b/diversity-page/ethnicity/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Staff by Race/Ethnicity</title>
+  <title>CSIS Staff by Race/Ethnicity, Dec 2019</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/ethnicity/js/bar.js
+++ b/diversity-page/ethnicity/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Race/Ethnicity*"
+    text: "Race/Ethnicity*, Dec 2019"
   },
   // Credits
   credits: {

--- a/diversity-page/gender/index.html
+++ b/diversity-page/gender/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Staff by Gender</title>
+  <title>CSIS Staff by Gender, Dec 2019</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/gender/js/bar.js
+++ b/diversity-page/gender/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Gender*"
+    text: "Gender*, Dec 2019"
   },
   // Credits
   credits: {

--- a/diversity-page/generation/index.html
+++ b/diversity-page/generation/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Staff by Generation</title>
+  <title>CSIS Staff by Generation, Dec 2019</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/generation/js/bar.js
+++ b/diversity-page/generation/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Generation"
+    text: "Generation, Dec 2019"
   },
   // Credits
   credits: {


### PR DESCRIPTION
Per Tucker's request, I added ", Dec 2019 to the chart titles.  I double checked about the titles with an "*" and she wants the asterisk after Gender and Ethnicity.  Let me know if you have any questions.  Thanks!