### PR TITLE
Update diversity page with 2020 data

### DIFF
--- a/diversity-page/ethnicity/index.html
+++ b/diversity-page/ethnicity/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Staff by Race/Ethnicity, Dec 2019</title>
+  <title>CSIS Staff by Race/Ethnicity, December 2020</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/ethnicity/js/bar.js
+++ b/diversity-page/ethnicity/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Race/Ethnicity*, Dec 2019"
+    text: "Race/Ethnicity*, December 2020"
   },
   // Credits
   credits: {

--- a/diversity-page/ethnicity/js/bar.js
+++ b/diversity-page/ethnicity/js/bar.js
@@ -10,7 +10,10 @@ Highcharts.chart('hcContainer', {
   },
   // Colors
   colors: [
-    '#66C6CB', '#0092A8', '#013446'
+    '#247877', // senior research staff
+    '#0FAA91', // junior research staff
+    '#004165', // senior admin staff
+    '#4CC7E6', // junior admin staff
   ],
   // Chart Title and Subtitle
   title: {

--- a/diversity-page/gender/index.html
+++ b/diversity-page/gender/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Staff by Gender, Dec 2019</title>
+  <title>CSIS Staff by Gender, December 2020</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/gender/js/bar.js
+++ b/diversity-page/gender/js/bar.js
@@ -10,7 +10,10 @@ Highcharts.chart('hcContainer', {
   },
   // Colors
   colors: [
-    '#66C6CB', '#0092A8', '#013446'
+    '#247877', // senior research staff
+    '#0FAA91', // junior research staff
+    '#004165', // senior admin staff
+    '#4CC7E6', // junior admin staff
   ],
   // Chart Title and Subtitle
   title: {

--- a/diversity-page/gender/js/bar.js
+++ b/diversity-page/gender/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Gender*, Dec 2019"
+    text: "Gender*, December 2020"
   },
   // Credits
   credits: {

--- a/diversity-page/generation/index.html
+++ b/diversity-page/generation/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <title>CSIS Staff by Generation, Dec 2019</title>
+    <title>CSIS Staff by Generation, December 2020</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Include Project Fonts -->

--- a/diversity-page/generation/js/bar.js
+++ b/diversity-page/generation/js/bar.js
@@ -10,7 +10,10 @@ Highcharts.chart('hcContainer', {
   },
   // Colors
   colors: [
-    '#66C6CB', '#0092A8', '#013446'
+    '#247877', // senior research staff
+    '#0FAA91', // junior research staff
+    '#004165', // senior admin staff
+    '#4CC7E6', // junior admin staff
   ],
   // Chart Title and Subtitle
   title: {

--- a/diversity-page/generation/js/bar.js
+++ b/diversity-page/generation/js/bar.js
@@ -14,7 +14,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Generation, Dec 2019"
+    text: "Generation, December 2020"
   },
   // Credits
   credits: {

--- a/diversity-page/intern-ethnicity/index.html
+++ b/diversity-page/intern-ethnicity/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Interns by Race/Ethnicity, 2019</title>
+  <title>CSIS Interns by Race/Ethnicity, December 2020</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/intern-ethnicity/js/bar.js
+++ b/diversity-page/intern-ethnicity/js/bar.js
@@ -15,7 +15,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Race/Ethnicity*, 2019"
+    text: "Race/Ethnicity*, December 2020"
   },
   // Credits
   credits: {

--- a/diversity-page/intern-gender/index.html
+++ b/diversity-page/intern-gender/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Interns by Gender, 2019</title>
+  <title>CSIS Interns by Gender, December 2020</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/intern-gender/js/bar.js
+++ b/diversity-page/intern-gender/js/bar.js
@@ -15,7 +15,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Gender*, 2019"
+    text: "Gender*, December 2020"
   },
   // Credits
   credits: {

--- a/diversity-page/intern-gender/js/bar.js
+++ b/diversity-page/intern-gender/js/bar.js
@@ -41,9 +41,13 @@ Highcharts.chart('hcContainer', {
   // },
   // X Axis
   xAxis: {
-    type: 'category',
-    labels: {
-      enabled: false    
+    // type: 'category',
+    // labels: {
+    //   enabled: false
+    // }
+    categories: ['Male', 'Female'],
+    title: {
+        text: null
     }
   },
   // Y Axis

--- a/diversity-page/intern-gender/js/bar.js
+++ b/diversity-page/intern-gender/js/bar.js
@@ -11,7 +11,7 @@ Highcharts.chart('hcContainer', {
   },
   // Colors
   colors: [
-    '#66C6CB', '#0092A8', '#013446'
+    '#0065A4'
   ],
   // Chart Title and Subtitle
   title: {
@@ -26,11 +26,14 @@ Highcharts.chart('hcContainer', {
   // Chart Legend
   legend: {
     title: {
-      text: '<br/><span style="font-size: 12px; color: #808080; font-weight: normal">(Click to hide)</span>'
+      text: '<br/><span style="font-size: 12px; color: #808080; font-weight: normal">(Click to hide)</span>',
     },
     align: 'center',
     verticalAlign: 'bottom',
     layout: 'horizontal',
+    symbolHeight: .001, // to hide the symbol on the legend
+    symbolWidth: .001, // to hide the symbol on the legend
+    symbolRadius: .001 // to hide the symbol on the legend
   },
   //  Tooltip 
   // tooltip: {
@@ -40,7 +43,7 @@ Highcharts.chart('hcContainer', {
   xAxis: {
     type: 'category',
     labels: {
-      enabled: false
+      enabled: false    
     }
   },
   // Y Axis
@@ -50,8 +53,7 @@ Highcharts.chart('hcContainer', {
     },
   },
   // Additional Plot Options
-  plotOptions:
-  {
+  plotOptions: {
     column: {
       stacking: null, // Normal bar graph
       // stacking: "normal", // Stacked bar graph

--- a/diversity-page/intern-gender/js/bar.js
+++ b/diversity-page/intern-gender/js/bar.js
@@ -3,7 +3,6 @@ Highcharts.chart('hcContainer', {
   data: {
     googleSpreadsheetKey: '1susmb2O7l-sRkILnlxZyatXmtebTrGjQk_K-qPqjzgs',
     googleSpreadsheetWorksheet: 4,
-    switchRowsAndColumns: true
   },
   // General Chart Options
   chart: {
@@ -25,30 +24,10 @@ Highcharts.chart('hcContainer', {
   },
   // Chart Legend
   legend: {
-    title: {
-      text: '<br/><span style="font-size: 12px; color: #808080; font-weight: normal">(Click to hide)</span>',
-    },
-    align: 'center',
-    verticalAlign: 'bottom',
-    layout: 'horizontal',
-    symbolHeight: .001, // to hide the symbol on the legend
-    symbolWidth: .001, // to hide the symbol on the legend
-    symbolRadius: .001 // to hide the symbol on the legend
+    enabled: false
   },
-  //  Tooltip 
-  // tooltip: {
-  //   shared: true,
-  // },
   // X Axis
   xAxis: {
-    // type: 'category',
-    // labels: {
-    //   enabled: false
-    // }
-    categories: ['Male', 'Female'],
-    title: {
-        text: null
-    }
   },
   // Y Axis
   yAxis: {

--- a/diversity-page/intern-generation/index.html
+++ b/diversity-page/intern-generation/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CSIS Interns by Generation, 2019</title>
+  <title>CSIS Interns by Generation, December 2020</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Include Project Fonts -->

--- a/diversity-page/intern-generation/js/bar.js
+++ b/diversity-page/intern-generation/js/bar.js
@@ -11,7 +11,7 @@ Highcharts.chart('hcContainer', {
   },
   // Colors
   colors: [
-    '#66C6CB', '#0092A8', '#013446'
+    '#0065A4'
   ],
   // Chart Title and Subtitle
   title: {
@@ -31,6 +31,9 @@ Highcharts.chart('hcContainer', {
     align: 'center',
     verticalAlign: 'bottom',
     layout: 'horizontal',
+    symbolHeight: .001, // to hide the symbol on the legend
+    symbolWidth: .001, // to hide the symbol on the legend
+    symbolRadius: .001 // to hide the symbol on the legend
   },
   //  Tooltip 
   // tooltip: {
@@ -42,6 +45,10 @@ Highcharts.chart('hcContainer', {
     labels: {
       enabled: false
     }
+    // categories: ['Male', 'Female'],
+    // title: {
+    //     text: null
+    // }
   },
   // Y Axis
   yAxis: {

--- a/diversity-page/intern-generation/js/bar.js
+++ b/diversity-page/intern-generation/js/bar.js
@@ -45,10 +45,6 @@ Highcharts.chart('hcContainer', {
     labels: {
       enabled: false
     }
-    // categories: ['Male', 'Female'],
-    // title: {
-    //     text: null
-    // }
   },
   // Y Axis
   yAxis: {

--- a/diversity-page/intern-generation/js/bar.js
+++ b/diversity-page/intern-generation/js/bar.js
@@ -15,7 +15,7 @@ Highcharts.chart('hcContainer', {
   ],
   // Chart Title and Subtitle
   title: {
-    text: "Generation, 2019"
+    text: "Generation, December 2020"
   },
   // Credits
   credits: {

--- a/diversity-page/intern-generation/js/bar.js
+++ b/diversity-page/intern-generation/js/bar.js
@@ -3,7 +3,6 @@ Highcharts.chart('hcContainer', {
   data: {
     googleSpreadsheetKey: '1susmb2O7l-sRkILnlxZyatXmtebTrGjQk_K-qPqjzgs',
     googleSpreadsheetWorksheet: 6,
-    switchRowsAndColumns: true
   },
   // General Chart Options
   chart: {
@@ -25,26 +24,12 @@ Highcharts.chart('hcContainer', {
   },
   // Chart Legend
   legend: {
-    title: {
-      text: '<br/><span style="font-size: 12px; color: #808080; font-weight: normal">(Click to hide)</span>'
-    },
-    align: 'center',
-    verticalAlign: 'bottom',
-    layout: 'horizontal',
-    symbolHeight: .001, // to hide the symbol on the legend
-    symbolWidth: .001, // to hide the symbol on the legend
-    symbolRadius: .001 // to hide the symbol on the legend
+    enabled: false
   },
-  //  Tooltip 
-  // tooltip: {
-  //   shared: true,
-  // },
+
   // X Axis
   xAxis: {
-    type: 'category',
-    labels: {
-      enabled: false
-    }
+
   },
   // Y Axis
   yAxis: {
@@ -57,7 +42,6 @@ Highcharts.chart('hcContainer', {
   {
     column: {
       stacking: null, // Normal bar graph
-      // stacking: "normal", // Stacked bar graph
       dataLabels: {
         enabled: false,
       }


### PR DESCRIPTION
Hey @urchykli, here are the notes that Tucker gave me
```
OK, here are some notes for the charts.
Staff charts
Junior Admin Staff #4CC7E6
Senior Admin Staff #004165
Junior Research Staff #0FAA91
Senior Research Staff #247877
Intern Charts
Can we lose the color legend for the Intern Gender and Generations charts? Just label the columns directly (notice the labels on the X axis in the column charts in the section above), and apply  #0065A4
For the Intern Demographics: if possible, it would be better to have this be a horizontal bar chart (ordered with largest bar at the top) and make all the bars #0065A4.
```

So far I was able to put only one label 'male' under the bars, for the interns charts.
![Screenshot at 2021-07-07 16-28-54](https://user-images.githubusercontent.com/51330062/124824522-78a65600-df40-11eb-912b-047da6f4d88f.png)
I would love to heard if you have any suggestion.
Also let me know what are your opinion about changing the chart to be an horizontal bar chart?
