### PR TITLE
Add Ukraine Commission Column Chart

### DIFF
--- a/ukraine-commission/index.html
+++ b/ukraine-commission/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Corruption and Freedom Scores</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <!--Highcharts chart container and caption-->
+    <div class="container">
+      <div id="rank" class="chart"></div>
+      <div id="score" class="chart"></div>
+      <div id="freedom" class="chart is-active"></div>
+    </div>
+
+    <!--Buttons for switching between charts-->
+    <div id="btnContainer" class="btn-container freedom">
+      <button type="button" id="transparency" class="btn">
+        Transparency International
+      </button>
+      <button type="button" id="freedomHouse" class="btn is-selected">
+        Freedom House
+      </button>
+      <button type="button" id="corruptionScore" class="btn is-inactive">
+        Score
+      </button>
+      <button type="button" id="corruptionRank" class="btn is-inactive">
+        Rank
+      </button>
+    </div>
+
+    <!--Highcharts libraries-->
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/highcharts-more.js"></script>
+    <script src="https://code.highcharts.com/modules/data.js"></script>
+    <script src="https://code.highcharts.com/maps/modules/exporting.js"></script>
+
+    <!-- Include Project Specific Javascript Files -->
+    <script src="js/column.js"></script>
+  </body>
+</html>

--- a/ukraine-commission/js/column.js
+++ b/ukraine-commission/js/column.js
@@ -1,0 +1,310 @@
+// Options for all charts: year colors, font
+Highcharts.setOptions({
+  colors: ["#edb21b", "#6dadd1", "#064265"],
+  chart: {
+    style: {
+      fontFamily: "'Source Sans Pro', sans-serif",
+    },
+  },
+});
+
+/*----Three Charts----*/
+// Corruption Perceptions Index: Score
+var rank = Highcharts.chart("rank", {
+  chart: {
+    renderTo: "rank",
+    type: "column",
+    zoomType: "xy",
+  },
+  title: {
+    text: "Corruption Perceptions Index: Rank",
+    margin: 100,
+  },
+  credits: {
+    enabled: true,
+    href: false,
+    text: "CSIS | Source: Transparency International",
+  },
+  xAxis: {
+    categories: ["Ukraine", "Poland", "Czech Republic", "Romania"],
+    crosshair: true,
+  },
+  yAxis: {
+    min: 0,
+    title: {
+      text: "Rank",
+    },
+  },
+  tooltip: {
+    headerFormat: '<span style="font-size:14px">{point.key}</span><br>',
+    shared: true,
+    useHTML: true,
+    style: {
+      lineHeight: "21px",
+    },
+  },
+  legend: {
+    itemStyle: {
+      color: "#000",
+      opacity: 0.5,
+    },
+  },
+  plotOptions: {
+    column: {
+      pointPadding: 0.2,
+      borderWidth: 0,
+    },
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 600,
+        },
+        // Make the labels less space demanding on mobile
+        chartOptions: {
+          legend: {
+            y: -8,
+          },
+          credits: {
+            position: {
+              y: -15,
+            },
+            text: "CSIS | Source: Transparency International",
+          },
+        },
+      },
+    ],
+  },
+  series: [
+    { name: "2015", data: [130, 26, 38, 58] },
+    { name: "2018", data: [112, 42, 49, 66] },
+    { name: "2021", data: [120, 36, 38, 61] },
+  ],
+});
+// Corruption Perceptions Index: Rank
+var score = Highcharts.chart("score", {
+  chart: {
+    renderTo: "score",
+    type: "column",
+    zoomType: "xy",
+  },
+  title: {
+    text: "Corruption Perceptions Index: Score",
+    margin: 100,
+  },
+  credits: {
+    enabled: true,
+    href: false,
+    text: "CSIS | Source: Transparency International",
+  },
+  xAxis: {
+    categories: ["Ukraine", "Poland", "Czech Republic", "Romania"],
+    crosshair: true,
+  },
+  yAxis: {
+    min: 0,
+    max: 100,
+    title: {
+      text: "Score",
+    },
+  },
+  tooltip: {
+    headerFormat: '<span style="font-size:14px">{point.key}</span><br>',
+    shared: true,
+    useHTML: true,
+    style: {
+      lineHeight: "21px",
+    },
+  },
+  legend: {
+    itemStyle: {
+      color: "#000",
+      opacity: 0.5,
+    },
+  },
+  plotOptions: {
+    column: {
+      pointPadding: 0.2,
+      borderWidth: 0,
+    },
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 600,
+        },
+        // Make the labels less space demanding on mobile
+        chartOptions: {
+          legend: {
+            y: -8,
+          },
+          credits: {
+            position: {
+              y: -15,
+            },
+            text: "CSIS | Source: Transparency International",
+          },
+        },
+      },
+    ],
+  },
+  series: [
+    { name: "2015", data: [27, 63, 56, 46] },
+    { name: "2018", data: [32, 56, 54, 45] },
+    { name: "2021", data: [32, 60, 59, 47] },
+  ],
+});
+// Freedom House Score
+var freedom = Highcharts.chart("freedom", {
+  chart: {
+    renderTo: "freedom",
+    type: "column",
+    zoomType: "xy",
+  },
+  title: {
+    text: "Freedom House Score",
+    margin: 100,
+  },
+  credits: {
+    enabled: true,
+    href: false,
+    text: "CSIS | Source: Freedom House",
+  },
+  xAxis: {
+    categories: ["Ukraine", "Poland", "Czech Republic", "Romania"],
+    crosshair: true,
+  },
+  yAxis: {
+    min: 0,
+    title: {
+      text: "Score",
+    },
+  },
+  tooltip: {
+    headerFormat: '<span style="font-size:14px">{point.key}</span><br>',
+    shared: true,
+    useHTML: true,
+    style: {
+      lineHeight: "21px",
+    },
+  },
+  legend: {
+    itemStyle: {
+      color: "#000",
+      opacity: 0.5,
+    },
+  },
+  plotOptions: {
+    column: {
+      pointPadding: 0.2,
+      borderWidth: 0,
+    },
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 600,
+        },
+        // Make the labels less space demanding on mobile
+        chartOptions: {
+          legend: {
+            y: -8,
+          },
+          credits: {
+            position: {
+              y: -15,
+            },
+            text: "CSIS | Source: Freedom House",
+          },
+        },
+      },
+    ],
+  },
+  series: [
+    { name: "2015", data: [62, 93, 95, 83] },
+    { name: "2018", data: [62, 85, 93, 83] },
+    { name: "2021", data: [60, 82, 91, 83] },
+  ],
+});
+
+/*----Select buttons and their container to add event listeners----*/
+const btnTransparency = document.getElementById("transparency");
+const btnFreedomHouse = document.getElementById("freedomHouse");
+const btnScore = document.getElementById("corruptionScore");
+const btnRank = document.getElementById("corruptionRank");
+const btnContainer = document.getElementById("btnContainer");
+
+/*----Select charts to add event listeners----*/
+var rank = document.getElementById("rank");
+var score = document.getElementById("score");
+var freedom = document.getElementById("freedom");
+
+/*----Add event listeners----*/
+// Transparency International Button
+btnTransparency.addEventListener("click", function () {
+  /********Deal with Buttons********/
+  // remove Transparency Int'l button
+  // make Freedom House button background transparent
+  btnTransparency.remove();
+  btnFreedomHouse.classList.remove("is-selected");
+
+  // make Score and Rank buttons visible
+  // make "Rank" button blue
+  btnScore.classList.remove("is-inactive");
+  btnRank.classList.remove("is-inactive");
+  btnRank.classList.add("is-selected");
+
+  // move Rank and Score in front of Freedom House button
+  // adjust container `left` to account for extra buttons
+  btnContainer.prepend(btnScore);
+  btnContainer.prepend(btnRank);
+  btnContainer.classList.add("transparency");
+
+  /********Deal with Charts********/
+  rank.classList.add("is-active");
+  freedom.classList.remove("is-active");
+});
+// Freedom House Button
+btnFreedomHouse.addEventListener("click", function () {
+  /********Deal with Buttons********/
+  // rake Freedom House button blue
+  btnFreedomHouse.classList.add("is-selected");
+
+  // remove `Rank` and `Score` buttons
+  btnScore.remove();
+  btnRank.remove();
+
+  // remove selected state from Rank and Score buttons
+  btnScore.classList.remove("is-selected");
+  btnRank.classList.remove("is-selected");
+
+  // add Transparency Int'l button back in
+  btnContainer.prepend(btnTransparency);
+
+  // adjust container 'left' to account for fewer buttons
+  btnContainer.classList.add("freedom");
+
+  /********Deal with Charts********/
+  score.classList.remove("is-active");
+  rank.classList.remove("is-active");
+  freedom.classList.add("is-active");
+});
+// Score button
+btnScore.addEventListener("click", function () {
+  btnScore.classList.add("is-selected");
+  btnRank.classList.remove("is-selected");
+  btnFreedomHouse.classList.remove("is-selected");
+  score.classList.add("is-active");
+  rank.classList.remove("is-active");
+});
+// Rank button
+btnRank.addEventListener("click", function () {
+  btnScore.classList.remove("is-selected");
+  btnRank.classList.add("is-selected");
+  btnFreedomHouse.classList.remove("is-selected");
+  rank.classList.add("is-active");
+  score.classList.remove("is-active");
+});

--- a/ukraine-commission/style.css
+++ b/ukraine-commission/style.css
@@ -1,0 +1,85 @@
+.container {
+  position: relative;
+}
+
+.chart {
+  position: absolute;
+  visibility: hidden;
+  opacity: 0;
+  width: 100%;
+}
+
+.is-active {
+  position: relative;
+  visibility: visible;
+  opacity: 1;
+}
+
+.is-inactive {
+  position: relative;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.btn {
+  align-self: auto | flex-start;
+  display: block;
+  margin: 0;
+  padding: 0.25rem 0.75rem;
+  color: #000;
+  font-family: Roboto, sans-serif;
+  font-size: 13px;
+  font-size: 0.8125rem;
+  line-height: 1.69;
+  letter-spacing: 0.7px;
+  background: transparent;
+  border: 1px solid #d4d0cb;
+  border-radius: 2px 0 0 2px;
+  transition: all 0.3s ease-in-out;
+}
+
+.btn:not([disabled]) {
+  cursor: pointer;
+}
+
+.btn.is-selected {
+  color: #fff;
+  background-color: #0054a4;
+  border: 1px solid #303f46;
+}
+
+.btn-container {
+  position: absolute;
+  top: 40px;
+  display: flex;
+  box-sizing: border-box;
+  height: 30px;
+  margin: 0;
+  font-size: 15px;
+  font-size: 0.9375rem;
+  line-height: 1.28571em;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  background-repeat: no-repeat;
+  background-position: 100%;
+  background-size: 30px 30px, 30px 30px;
+  border: none;
+  border-radius: 2px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  pointer-events: auto;
+}
+
+.btn-container.freedom {
+  left: calc(50vw - 150px);
+}
+
+.btn-container.transparency {
+  left: calc(50vw - 130px);
+}
+
+@media only screen and (min-width: 700px) {
+  .btn-container {
+    top: 65px;
+  }
+}


### PR DESCRIPTION
## What
This chart was based on a [cpower chart](https://csis-cpower-viz.netlify.app/health-security-highcharts/covid-19-cases/ ) that uses buttons to switch between two different charts.

The HTML starts out with the Rank and Score buttons hidden -- it makes the event listeners less ugly to be able to select them initially and then add/remove them as needed. 

The event listener for the "Freedom House" button makes sure to remove `is-selected` from the `Rank` and `Score` buttons. This guarantees that regardless of which chart the user is on when they go back to `Freedom House`, when they navigate back to `Transparency International` only the `Rank` button is selected.

## Video
https://user-images.githubusercontent.com/41589348/193325841-73fef241-6306-4854-93f2-e1c54b6cd45d.mov

