### PR TITLE
Adjust buttons for mobile

### DIFF
--- a/ukraine-commission/js/column.js
+++ b/ukraine-commission/js/column.js
@@ -319,6 +319,7 @@ btnTransparency.addEventListener("click", function () {
   btnContainer.prepend(btnScore);
   btnContainer.prepend(btnRank);
   btnContainer.classList.add("transparency");
+  btnContainer.classList.remove("freedom");
 
   /********Deal with Charts********/
   rank.classList.add("is-active");

--- a/ukraine-commission/style.css
+++ b/ukraine-commission/style.css
@@ -70,6 +70,25 @@
   pointer-events: auto;
 }
 
+@media only screen and (max-width: 350px) {
+  .btn-container.transparency {
+    top: 65px;
+  }
+
+  .btn-container.freedom {
+    left: calc(50vw - 162px) !important;
+  }
+}
+
+@media only screen and (max-width: 290px) {
+  .btn-container.freedom {
+    left: calc(50vw - 140px) !important;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
 .btn-container.freedom {
   left: calc(50vw - 150px);
 }


### PR DESCRIPTION
## What
In the Shorthand piece this is for, the buttons got pushed up too far on mobile and ran into the text. Added breakpoints to push them down and on something very narrow - like the Galaxy Fold - stack the initial buttons.

## Screenshots
### Before
<img width="400" alt="Screen Shot 2022-10-07 at 11 16 17 AM" src="https://user-images.githubusercontent.com/41589348/194589424-f0fb4335-6d49-438c-bb84-acdae00af411.png">

### After
<img width="386" alt="Screen Shot 2022-10-07 at 11 15 27 AM" src="https://user-images.githubusercontent.com/41589348/194589501-e78efb0b-4910-426f-9e41-78219f0ef36f.png">

<img width="367" alt="Screen Shot 2022-10-07 at 11 15 46 AM" src="https://user-images.githubusercontent.com/41589348/194589701-2d60b06d-c532-4d7b-8056-4e95d87a65be.png">
